### PR TITLE
inch should be lenient with malformed YARD @overload parameters

### DIFF
--- a/lib/inch/code_object/provider/yard/object/method_object.rb
+++ b/lib/inch/code_object/provider/yard/object/method_object.rb
@@ -123,7 +123,7 @@ module Inch
             # @todo analyse each signature on its own
             def overloaded_parameter_names
               overload_tags.map do |tag|
-                tag.parameters.map do |parameter|
+                Array(tag.parameters).map do |parameter|
                   normalize_parameter_name(parameter[0])
                 end
               end.flatten

--- a/test/fixtures/simple/lib/broken.rb
+++ b/test/fixtures/simple/lib/broken.rb
@@ -170,6 +170,15 @@ module Overloading
   #   @return [Array<Symbol>] The identifiers for this class
   def identifiers(*identifiers)
   end
+
+  # @overload missing_param_names
+  #
+  #
+  #   @param [Array<Symbol>] This param is not given in the overload above.
+  #
+  #   @return [void]
+  def missing_param_names(*identifiers)
+  end
 end
 
 module YardError

--- a/test/unit/code_object/proxy/method_object_test.rb
+++ b/test/unit/code_object/proxy/method_object_test.rb
@@ -282,4 +282,9 @@ describe ::Inch::CodeObject::Proxy::MethodObject do
       assert_equal 100, m.score, "#{m.fullname} did not get 100"
     end
   end
+
+  def test_overloading_with_bad_doc
+    m = @objects.find("Overloading#missing_param_names")
+    refute m.has_doc? # it may be mentioned in the docs, but it's malformed.
+  end
 end


### PR DESCRIPTION
I ran `inch` against a problem with malformed YARD @overload parameters and got this stack trace:

```
/Volumes/TempStorage/rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/inch-0.4.0/lib/inch/code_object/provider/yard/object/method_object.rb:126:in `block in overloaded_parameter_names': undefined method `map' for nil:NilClass (NoMethodError)
    from /Volumes/TempStorage/rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/inch-0.4.0/lib/inch/code_object/provider/yard/object/method_object.rb:125:in `map'
    from /Volumes/TempStorage/rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/inch-0.4.0/lib/inch/code_object/provider/yard/object/method_object.rb:125:in `overloaded_parameter_names'
    from /Volumes/TempStorage/rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/inch-0.4.0/lib/inch/code_object/provider/yard/object/method_object.rb:145:in `signature_parameter_names'
    from /Volumes/TempStorage/rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/inch-0.4.0/lib/inch/code_object/provider/yard/object/method_object.rb:90:in `all_parameter_names'
```

From a method incorrectly documented like:

``` ruby
# note the @overload doesn't list any params, but a @param is in the YARD doc anyway.
# @overload do_something
#   @param [Symbol] an i18n key 
def do_something *args
end
```

It'd be nice if inch reported this better, but silently ignoring the problem (and just taking the doc coverage hit) seemed straightforward enough.
