### PR TITLE
Added exit_status to command line and check on suggest

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,8 @@ It comes with four sub-commands: `suggest`, `stats`, `show`, and `list`
 
 ### inch suggest
 
-Suggests places where a codebase suffers a lack of documentation.
+Suggests places where a codebase suffers a lack of documentation. The command
+line exit status will be above zero when suggestions are found.
 
     $ inch suggest
 

--- a/bin/inch
+++ b/bin/inch
@@ -20,4 +20,5 @@ $LOAD_PATH.unshift(find_lib_path)
 require 'inch'
 require 'inch/cli'
 
-Inch::CLI::CommandParser.run(*ARGV)
+command = Inch::CLI::CommandParser.run(*ARGV)
+exit(command.exit_status)

--- a/lib/inch/cli/command/base.rb
+++ b/lib/inch/cli/command/base.rb
@@ -36,6 +36,9 @@ module Inch
       # @note This was adapted from YARD
       #   https://github.com/lsegal/yard/blob/master/lib/yard/cli/command.rb
       class Base
+        EXIT_NO_ERRORS = 0
+        EXIT_WITH_ERRORS = 64
+
         include TraceHelper
 
         attr_reader :codebase # @return [Codebase::Proxy]
@@ -96,6 +99,13 @@ module Inch
         # @return [String]
         def usage
           "Usage: inch #{name} [options]"
+        end
+
+        # Retun exit status for command line
+        #
+        # @return [Integer] Zero by default
+        def exit_status
+          EXIT_NO_ERRORS
         end
 
         protected

--- a/lib/inch/cli/command/suggest.rb
+++ b/lib/inch/cli/command/suggest.rb
@@ -23,11 +23,23 @@ module Inch
         def run(*args)
           prepare_codebase(*args)
           context = API::Suggest.new(codebase, @options)
+          self.objects = context.objects
           if @options.format == Options::Suggest::FORMAT_TEXT
-            Output::Suggest.new(@options, context.all_objects, context.objects,
+            Output::Suggest.new(@options, context.all_objects, objects,
                                 context.grade_lists, context.files)
           else
             Output::Stats.new(@options, context.all_objects, context.grade_lists)
+          end
+        end
+
+        # Retun exit status for command line
+        #
+        # @return [Integer] Zero when no errors, above when suggestions
+        def exit_status
+          if objects.empty?
+            EXIT_NO_ERRORS
+          else
+            EXIT_WITH_ERRORS
           end
         end
       end

--- a/test/integration/cli/command/console_test.rb
+++ b/test/integration/cli/command/console_test.rb
@@ -12,6 +12,12 @@ describe ::Inch::CLI::Command::Console do
     @command = ::Inch::CLI::Command::Console
   end
 
+  it 'should run with exit status' do
+    _out, _err = capture_io do
+      assert_equal @command.run.exit_status, @command::EXIT_NO_ERRORS
+    end
+  end
+
   it 'should output info when run with --help' do
     out, err = capture_io do
       assert_raises(SystemExit) { @command.run('--help') }

--- a/test/integration/cli/command/diff_test.rb
+++ b/test/integration/cli/command/diff_test.rb
@@ -23,6 +23,12 @@ describe ::Inch::CLI::Command::Diff do
     FileUtils.rm_rf @tmp_dir
   end
 
+  it 'should run with exit status' do
+    _out, _err = capture_io do
+      assert_equal @command.run.exit_status, @command::EXIT_NO_ERRORS
+    end
+  end
+
   it 'should not show any changes' do
     # this runs `inch diff` on a freshly cloned repo
     # should not show any changes

--- a/test/integration/cli/command/inspect_test.rb
+++ b/test/integration/cli/command/inspect_test.rb
@@ -6,6 +6,13 @@ describe ::Inch::CLI::Command::Inspect do
     @command = ::Inch::CLI::Command::Inspect
   end
 
+  it 'should run with exit status' do
+    _out, _err = capture_io do
+      cmd = @command.run('Foo::Bar#', '--no-color')
+      assert_equal cmd.exit_status, @command::EXIT_NO_ERRORS
+    end
+  end
+
   it 'should warn and exit when run without args' do
     out, err = capture_io do
       assert_raises(SystemExit) { @command.run }

--- a/test/integration/cli/command/list_test.rb
+++ b/test/integration/cli/command/list_test.rb
@@ -9,6 +9,12 @@ describe ::Inch::CLI::Command::List do
 
   include Shared::BaseList
 
+  it 'should run with exit status' do
+    _out, _err = capture_io do
+      assert_equal @command.run.exit_status, @command::EXIT_NO_ERRORS
+    end
+  end
+
   it 'should run without args' do
     out, err = capture_io do
       @command.run

--- a/test/integration/cli/command/show_test.rb
+++ b/test/integration/cli/command/show_test.rb
@@ -6,6 +6,13 @@ describe ::Inch::CLI::Command::Show do
     @command = ::Inch::CLI::Command::Show
   end
 
+  it 'should run with exit status' do
+    _out, _err = capture_io do
+      cmd = @command.run('Foo::Bar#', '--no-color')
+      assert_equal cmd.exit_status, @command::EXIT_NO_ERRORS
+    end
+  end
+
   it 'should warn and exit when run without args' do
     out, err = capture_io do
       assert_raises(SystemExit) { @command.run }

--- a/test/integration/cli/command/stats_test.rb
+++ b/test/integration/cli/command/stats_test.rb
@@ -6,6 +6,12 @@ describe ::Inch::CLI::Command::Stats do
     @command = ::Inch::CLI::Command::Stats
   end
 
+  it 'should run with exit status' do
+    _out, _err = capture_io do
+      assert_equal @command.run.exit_status, @command::EXIT_NO_ERRORS
+    end
+  end
+
   it 'should run without args' do
     out, err = capture_io do
       @command.run

--- a/test/integration/cli/command/suggest_test.rb
+++ b/test/integration/cli/command/suggest_test.rb
@@ -7,6 +7,12 @@ describe ::Inch::CLI::Command::Suggest do
     @command = ::Inch::CLI::Command::Suggest
   end
 
+  it 'should run with exit status' do
+    _out, _err = capture_io do
+      assert_equal @command.run.exit_status, @command::EXIT_WITH_ERRORS
+    end
+  end
+
   it 'should run without args' do
     out, err = capture_io do
       @command.run
@@ -92,6 +98,13 @@ describe ::Inch::CLI::Command::Suggest do
   end
 
   # Edge case: Really good codebase
+
+  it 'should return EXIT_NO_ERRORS when no suggestions' do
+    Dir.chdir fixture_path(:ruby, :really_good)
+    _out, _err = capture_io do
+      assert_equal @command.run.exit_status, @command::EXIT_NO_ERRORS
+    end
+  end
 
   it 'should run without args on really good fixture' do
     out, err = capture_io do


### PR DESCRIPTION
Exit status stay zero by default, but for `suggest` return above zero when suggestions are found.
Can be useful for CI check.