### PR TITLE
Prevent test suite from erring out partway through

### DIFF
--- a/lib/inch/cli/command_parser.rb
+++ b/lib/inch/cli/command_parser.rb
@@ -34,6 +34,11 @@ module Inch
     class CommandParser
       include TraceHelper
 
+      # Represents a fake command, i.e. `--help` for use in the CLI.
+      #
+      # @api private
+      FakeCommand = Struct.new(:exit_status)
+
       class << self
         # @return [Hash{Symbol => Command}] the mapping of command names to
         #   command classes to parse the user command.
@@ -77,7 +82,7 @@ module Inch
           command = commands[command_name].new
           ui.trace format('  %-8s %s', command_name, command.description)
         end
-        exit 0
+        FakeCommand.new(0)
       end
 
       # Runs the {Command} object matching the command name of the first


### PR DESCRIPTION
Because the `CommandParser` had differing levels of responsibility
throughout its code paths, the test suite was erring out partway through
the test suite and not printing the results of running the whole suite.

By standardizing the `CommandParser.run` return value around a mock that
responds to `exit_status`, we leave the responsibility for exiting the
program to the `bin/inch` script instead of splitting it between the
script and the `CommandParser`. This change then allows the test suite
to continue past this test without issue.