### PR TITLE
Fix typos in code comments

### DIFF
--- a/lib/inch/language/elixir/roles/function.rb
+++ b/lib/inch/language/elixir/roles/function.rb
@@ -32,13 +32,13 @@ module Inch
               end
             end
 
-            # Role assigned to methods where the return value is decribed in the
+            # Role assigned to methods where the return value is described in the
             # docs
             class WithReturnDescription < Base
               applicable_if :return_described?
             end
 
-            # Role assigned to methods where the return value is not decribed
+            # Role assigned to methods where the return value is not described
             class WithoutReturnDescription < Missing
               applicable_unless :return_described?
 

--- a/lib/inch/language/javascript/roles/function.rb
+++ b/lib/inch/language/javascript/roles/function.rb
@@ -32,13 +32,13 @@ module Inch
               end
             end
 
-            # Role assigned to methods where the return value is decribed in the
+            # Role assigned to methods where the return value is described in the
             # docs
             class WithReturnDescription < Base
               applicable_if :return_described?
             end
 
-            # Role assigned to methods where the return value is not decribed
+            # Role assigned to methods where the return value is not described
             class WithoutReturnDescription < Missing
               applicable_unless :return_described?
 

--- a/lib/inch/language/ruby/roles/method.rb
+++ b/lib/inch/language/ruby/roles/method.rb
@@ -32,13 +32,13 @@ module Inch
               end
             end
 
-            # Role assigned to methods where the return value is decribed in the
+            # Role assigned to methods where the return value is described in the
             # docs
             class WithReturnDescription < Base
               applicable_if :return_described?
             end
 
-            # Role assigned to methods where the return value is not decribed
+            # Role assigned to methods where the return value is not described
             class WithoutReturnDescription < Missing
               applicable_unless :return_described?
 


### PR DESCRIPTION
This PR fixes a copy-and-paste typo in the code comments.

Command used:

`find . -name '*.rb'    | misspellings -f -`